### PR TITLE
hide the instructions

### DIFF
--- a/public/script-compiled.js
+++ b/public/script-compiled.js
@@ -231,6 +231,8 @@
       container.innerHTML = '';
       document.getElementById('activist-army-start').scrollIntoView();
       emailTemplate.style.display = 'none';
+      document.querySelector('.activist-instructions').style.display = 'none';
+
       showLoader('Sending emails...');
       sendEmails(
         emailArr,


### PR DESCRIPTION
in prev fix hid most of the instructions but not the h3, now h3 is hidden as well.
relates #84